### PR TITLE
Add GitHub Actions for issue lifecycle management

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,68 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for automating various aspects of our development process.
+
+## PR Status Tracking
+
+**File:** `pr-status-tracking.yml`
+
+This workflow automatically tracks the status of issues referenced in pull requests and updates their labels accordingly.
+
+### How It Works
+
+1. **When a Draft PR is created:**
+   - Referenced issues are labeled as `in-progress`
+   - A comment is added to the issue linking to the PR
+
+2. **When a PR is marked Ready for Review:**
+   - The `in-progress` label is removed
+   - Issues are labeled as `review-ready`
+
+3. **When a PR is merged to `develop`:**
+   - Issues are labeled as `merged-to-develop`
+   - Issues are NOT closed automatically at this stage
+
+4. **When a PR is merged to `main`:**
+   - Issues receive a `released` label
+   - GitHub will auto-close the issues if proper keywords were used
+
+### Usage
+
+Simply reference issues in your PR description using one of these keywords:
+- `Fixes #123`
+- `Resolves #123`
+- `Closes #123`
+
+The workflow will automatically track the status of these issues.
+
+## Release Management
+
+**File:** `release-management.yml`
+
+This workflow helps generate release PRs that include all issues that have been merged to develop but not yet released.
+
+### How It Works
+
+1. Creates a new release branch from `develop`
+2. Collects all issues with the `merged-to-develop` label
+3. Creates a PR from the release branch to `main` with:
+   - A list of all included issues
+   - References to automatically close these issues when merged
+
+### Usage
+
+Trigger this workflow manually from the Actions tab with:
+- **Version:** The version number for this release (e.g., `1.2.0`)
+
+The workflow will create a release PR that includes all pending issues.
+
+## Labels Used
+
+These workflows use the following labels:
+
+- `in-progress`: Issue is being worked on in a draft PR
+- `review-ready`: Work is complete and ready for review
+- `merged-to-develop`: Implementation has been merged to develop
+- `released`: Feature has been released to production
+
+Make sure these labels exist in your repository.

--- a/.github/workflows/pr-status-tracking.yml
+++ b/.github/workflows/pr-status-tracking.yml
@@ -1,0 +1,176 @@
+name: PR Status Tracking
+
+on:
+  pull_request:
+    types: [opened, converted_to_draft, ready_for_review, closed]
+
+jobs:
+  track-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Track Issue Status
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            
+            console.log(`Processing PR #${pr.number}: ${pr.title}`);
+            
+            // Extract issue numbers from PR body using regex
+            const issueRefs = pr.body ? pr.body.match(/(close[sd]?|fix(es|ed)?|resolve[sd]?)\s*:?\s*#(\d+)/gi) || [] : [];
+            const issueNumbers = issueRefs.map(ref => parseInt(ref.match(/#(\d+)/)[1]));
+            
+            if (issueNumbers.length === 0) {
+              console.log('No issue references found in PR');
+              return;
+            }
+            
+            console.log(`Found referenced issues: ${issueNumbers.join(', ')}`);
+            
+            // Process each referenced issue
+            for (const issueNumber of issueNumbers) {
+              console.log(`Processing issue #${issueNumber}`);
+              
+              // Handle different PR states
+              if (pr.draft) {
+                console.log(`PR #${pr.number} is a draft - adding in-progress label to issue #${issueNumber}`);
+                
+                // PR is a draft - add in-progress label
+                try {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels: ['in-progress']
+                  });
+                  
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: `This issue is being worked on in draft PR #${pr.number}`
+                  });
+                  
+                  console.log(`Added in-progress label and comment to issue #${issueNumber}`);
+                } catch (e) {
+                  console.error(`Error updating issue #${issueNumber}: ${e.message}`);
+                }
+              } 
+              else if (pr.state === 'open' && !pr.draft) {
+                console.log(`PR #${pr.number} is ready for review - updating issue #${issueNumber}`);
+                
+                // PR is ready for review - remove in-progress label, add review-ready
+                try {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      name: 'in-progress'
+                    });
+                    console.log(`Removed in-progress label from issue #${issueNumber}`);
+                  } catch (e) {
+                    console.log(`No in-progress label to remove from issue #${issueNumber}`);
+                  }
+                  
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels: ['review-ready']
+                  });
+                  
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: `Work on this issue is ready for review in PR #${pr.number}`
+                  });
+                  
+                  console.log(`Added review-ready label and comment to issue #${issueNumber}`);
+                } catch (e) {
+                  console.error(`Error updating issue #${issueNumber}: ${e.message}`);
+                }
+              } 
+              else if (pr.state === 'closed' && pr.merged) {
+                console.log(`PR #${pr.number} was merged - updating issue #${issueNumber}`);
+                
+                // PR was merged - handle based on target branch
+                const targetBranch = pr.base.ref;
+                
+                try {
+                  if (targetBranch === 'develop') {
+                    console.log(`PR was merged to develop - adding merged-to-develop label to issue #${issueNumber}`);
+                    
+                    // Remove review-ready label if it exists
+                    try {
+                      await github.rest.issues.removeLabel({
+                        owner,
+                        repo,
+                        issue_number: issueNumber,
+                        name: 'review-ready'
+                      });
+                      console.log(`Removed review-ready label from issue #${issueNumber}`);
+                    } catch (e) {
+                      console.log(`No review-ready label to remove from issue #${issueNumber}`);
+                    }
+                    
+                    // Add merged-to-develop label
+                    await github.rest.issues.addLabels({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      labels: ['merged-to-develop']
+                    });
+                    
+                    await github.rest.issues.createComment({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      body: `Implementation for this issue has been merged to the develop branch in PR #${pr.number}`
+                    });
+                    
+                    console.log(`Added merged-to-develop label and comment to issue #${issueNumber}`);
+                  }
+                  else if (targetBranch === 'main') {
+                    console.log(`PR was merged to main - adding released label to issue #${issueNumber}`);
+                    
+                    // Remove merged-to-develop label if it exists
+                    try {
+                      await github.rest.issues.removeLabel({
+                        owner,
+                        repo,
+                        issue_number: issueNumber,
+                        name: 'merged-to-develop'
+                      });
+                      console.log(`Removed merged-to-develop label from issue #${issueNumber}`);
+                    } catch (e) {
+                      console.log(`No merged-to-develop label to remove from issue #${issueNumber}`);
+                    }
+                    
+                    // Add released label
+                    await github.rest.issues.addLabels({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      labels: ['released']
+                    });
+                    
+                    await github.rest.issues.createComment({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      body: `This feature has been released to production in PR #${pr.number}`
+                    });
+                    
+                    console.log(`Added released label and comment to issue #${issueNumber}`);
+                    
+                    // Note: GitHub will auto-close the issue if proper keywords were used
+                  }
+                } catch (e) {
+                  console.error(`Error updating issue #${issueNumber}: ${e.message}`);
+                }
+              }
+            }

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -1,0 +1,100 @@
+name: Generate Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.2.0)'
+        required: true
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Create Release Branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git checkout develop
+          git pull
+          git checkout -b release/v${{ github.event.inputs.version }}
+          git push -u origin release/v${{ github.event.inputs.version }}
+      
+      - name: Collect Pending Issues
+        id: collect-issues
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            
+            console.log('Collecting issues with merged-to-develop label');
+            
+            // Get all issues with 'merged-to-develop' label
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'merged-to-develop'
+            });
+            
+            console.log(`Found ${issues.length} issues with merged-to-develop label`);
+            
+            // Format issues for PR description
+            let issueList = '';
+            let issueRefs = '';
+            
+            issues.forEach(issue => {
+              issueList += `- #${issue.number}: ${issue.title}\n`;
+              issueRefs += `Fixes #${issue.number}\n`;
+              console.log(`Including issue #${issue.number}: ${issue.title}`);
+            });
+            
+            // Return as a stringified JSON object to preserve formatting
+            return {
+              result: JSON.stringify({ issueList, issueRefs })
+            };
+      
+      - name: Create Release PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const version = '${{ github.event.inputs.version }}';
+            
+            // Parse the JSON string back to an object
+            const { issueList, issueRefs } = JSON.parse(${{ steps.collect-issues.outputs.result }});
+            
+            console.log(`Creating release PR for version ${version}`);
+            
+            const body = `# Release v${version}
+
+## Issues included in this release:
+${issueList}
+
+## Changelog
+[Add release notes here]
+
+${issueRefs}`;
+            
+            const { data: pr } = await github.rest.pulls.create({
+              owner,
+              repo,
+              title: `Release v${version}`,
+              head: `release/v${version}`,
+              base: 'main',
+              body: body
+            });
+            
+            console.log(`Created release PR #${pr.number}`);
+            
+            return {
+              pr_number: pr.number,
+              pr_url: pr.html_url
+            };


### PR DESCRIPTION
# Add GitHub Actions for issue lifecycle management

This PR implements GitHub Actions to automate the issue lifecycle management across our repositories. These actions will standardize how we track issues through the development process and ensure consistent practices.

## Changes

- Added `pr-status-tracking.yml` workflow that:
  - Labels issues as `in-progress` when referenced in Draft PRs
  - Updates labels to `review-ready` when PRs are marked ready
  - Adds `merged-to-develop` label when PRs are merged to develop
  - Adds comments to issues at each stage

- Added `release-management.yml` workflow that:
  - Collects all issues with `merged-to-develop` label
  - Automatically includes them in release PRs
  - Ensures issues are closed when merged to main
  - Adds `released` label to closed issues

- Added README.md with detailed documentation on how these workflows function

## Testing

These workflows will need to be tested by:
1. Creating a draft PR that references an issue
2. Converting it to ready for review
3. Merging it to develop
4. Using the release workflow to create a release PR

## Notes

Before these workflows can be fully effective, we need to ensure that all repositories have the required labels:
- `in-progress`
- `review-ready`
- `merged-to-develop`
- `released`

Fixes #18
