### PR TITLE
Implement GitHub Action to enforce CONTRIBUTING.md references

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,6 +56,28 @@ Trigger this workflow manually from the Actions tab with:
 
 The workflow will create a release PR that includes all pending issues.
 
+## Enforce CONTRIBUTING.md References
+
+**File:** `enforce-contributing-references.yml`
+
+This workflow checks if new issues and PRs reference the contribution guidelines and adds a reminder comment if they don't.
+
+### How It Works
+
+1. Triggers when an issue or PR is opened or edited
+2. Checks if the body contains a reference to CONTRIBUTING.md or contribution guidelines
+3. If no reference is found, adds a comment with:
+   - A reminder to review the contribution guidelines
+   - A link to the CONTRIBUTING.md file
+   - Specific notes for AI assistants
+
+### Benefits
+
+- Ensures contributors are aware of the contribution guidelines
+- Provides a gentle reminder rather than blocking contributions
+- Includes specific guidance for AI assistants
+- Helps maintain consistent contribution practices
+
 ## Labels Used
 
 These workflows use the following labels:
@@ -69,7 +91,7 @@ These workflows use the following labels:
 
 ## Automatic Label Creation
 
-Both workflows include functionality to automatically create any required labels if they don't already exist in the repository. This means:
+Both the PR Status Tracking and Release Management workflows include functionality to automatically create any required labels if they don't already exist in the repository. This means:
 
 1. No manual setup of labels is required
 2. The workflows will work in any repository without prior configuration

--- a/.github/workflows/enforce-contributing-references.yml
+++ b/.github/workflows/enforce-contributing-references.yml
@@ -1,0 +1,84 @@
+name: Enforce CONTRIBUTING.md References
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-contributing-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for CONTRIBUTING.md reference
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            
+            // Determine if this is an issue or PR
+            const isIssue = !!context.payload.issue;
+            const item = isIssue ? context.payload.issue : context.payload.pull_request;
+            const itemType = isIssue ? 'issue' : 'pull request';
+            const itemNumber = item.number;
+            
+            console.log(`Checking ${itemType} #${itemNumber} for CONTRIBUTING.md reference`);
+            
+            // Check if the body contains a reference to CONTRIBUTING.md
+            const body = item.body || '';
+            const hasContributingReference = 
+              body.includes('CONTRIBUTING.md') || 
+              body.includes('contribution guidelines') ||
+              body.includes('contributing guidelines');
+            
+            if (!hasContributingReference) {
+              console.log(`No CONTRIBUTING.md reference found in ${itemType} #${itemNumber}`);
+              
+              // Create a comment with a reminder
+              const commentBody = `
+## Contribution Guidelines Reminder
+
+Thank you for your ${itemType}! 
+
+It appears that you haven't referenced our contribution guidelines. Please take a moment to review our [CONTRIBUTING.md](https://github.com/PitchConnect/contribution-guidelines/blob/main/CONTRIBUTING.md) file, which contains important information about:
+
+- Our development workflow
+- Coding standards
+- Pull request process
+- Issue lifecycle
+
+### For AI Assistants
+
+If you're an AI assistant, please note that:
+- You should always check all comments on issues and PRs, not just the initial description
+- Use GitHub CLI (gh) for GitHub operations when applicable
+- Follow our GitFlow branching model
+- Use pre-commit hooks to catch issues early
+
+Please update your ${itemType} to indicate that you've reviewed the contribution guidelines.
+`;
+              
+              try {
+                if (isIssue) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: itemNumber,
+                    body: commentBody
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: itemNumber,
+                    body: commentBody
+                  });
+                }
+                console.log(`Added CONTRIBUTING.md reminder comment to ${itemType} #${itemNumber}`);
+              } catch (error) {
+                console.error(`Error adding comment to ${itemType} #${itemNumber}: ${error.message}`);
+              }
+            } else {
+              console.log(`CONTRIBUTING.md reference found in ${itemType} #${itemNumber}`);
+            }


### PR DESCRIPTION
# Implement GitHub Action to enforce CONTRIBUTING.md references

This PR adds a GitHub Action that automatically checks if new issues and PRs reference the contribution guidelines and adds a reminder comment if they don't.

## Changes

- Added `enforce-contributing-references.yml` workflow that:
  - Triggers when an issue or PR is opened or edited
  - Checks if the body contains a reference to CONTRIBUTING.md or contribution guidelines
  - Adds a reminder comment with a link to the guidelines if no reference is found
  - Includes specific guidance for AI assistants

- Updated the README.md to document this new workflow

## Benefits

- Ensures contributors are aware of the contribution guidelines
- Provides a gentle reminder rather than blocking contributions
- Includes specific guidance for AI assistants
- Helps maintain consistent contribution practices across repositories

## Testing

This workflow has been tested by:
1. Creating test issues and PRs without CONTRIBUTING.md references
2. Verifying that the reminder comment is added correctly
3. Confirming that issues and PRs with proper references are not affected

## Implementation Details

The workflow uses GitHub Actions and the GitHub API to:
1. Check the content of new issues and PRs
2. Add a helpful comment with links to the guidelines
3. Provide specific guidance for different contributor types

This is a non-blocking implementation that encourages good practices without preventing contributions.

Fixes #16
